### PR TITLE
Bumped version to 0.0.3

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -2,7 +2,7 @@ config SND_I2S_RPI
 	tristate "I2S MEMs microphone"
 	select NLS
 	help
-	  This adds support for the Adafruits I2S soundcard.
+	  This adds support for the SPH0645LM4H I2S soundcard.
 
 config SND_I2S_RPI_DEBUG_MSG
 	bool "print debug messages"

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ clean:
 help:
 	$(MAKE) -C $(KDIR) M=$(PWD) help
 
-install: snd-2s_rpi.ko
+install: snd-i2s_rpi.ko
 	rm -f ${MDIR}/kernel/sound/drivers/$(MOD_NAME).ko
 	install -m644 -b -D $(MOD_NAME).ko ${MDIR}/kernel/sound/drivers/$(MOD_NAME).ko
 	depmod -aq

--- a/README.md
+++ b/README.md
@@ -1,74 +1,10 @@
-**Driver for the Adafruit I2S MEMS Microphone**
+**Driver for the SPH0645LM4H I2S MEMS Microphone**
 
 [Product learn page on Adafruit](https://learn.adafruit.com/adafruit-i2s-mems-microphone-breakout/overview).
 
-Known problems with this driver: Low vol level. While you can use the alsa magic socery to make an alsa softvol input, that approach won't work out of the box with anything that uses Pulseaudio. If you have any idea how to make this work with Pulse, please drop me a line.
-
-Installing the I2S microphone driver the easy way
-====================================
-
-If you use Raspbian or any Debian-derived distribution, [go to the releases tab](https://github.com/htruong/snd-i2s_rpi/releases) and download the newest deb version.
-
-Then do the following
-
-```bash
-
-# Installing raspberrypi-kernel-headers works only if you haven't messed with
-# the rpi-update thing.
-# If you did, then you would have to do the rpi-source method
-# to get the kernel headers. See: 
-# https://learn.adafruit.com/adafruit-i2s-mems-microphone-breakout/raspberry-pi-wiring-and-test#kernel-compiling
-
-$ sudo apt install dkms raspberrypi-kernel-headers
-
-$ sudo dpkg -i snd-i2s-rpi-dkms_0.0.2_all.deb
-
-# For this to work, remember to modify these first:
-# /boot/config.txt -> dtparam=i2s=on
-# and 
-# /etc/modules -> snd-bcm2835
-# remember to reboot
-
-$ sudo modprobe snd-i2s_rpi rpi_platform_generation=0
-
-# rpi_platform_generation=0 for Raspberry Pi 1 B/A/A+, 0
-# do not add anything for everything else (2/3).
-
-# see if it works
-
-$ dmesg | grep i2s
-
-# it should say blah.i2s mapping OK
-
-# [    3.519017] snd_i2s_rpi: loading out-of-tree module taints kernel.
-# [    3.519881] snd-i2s_rpi: Version 0.0.2
-# [    3.519889] snd-i2s_rpi: Setting platform to 20203000.i2s
-# [    7.624559] asoc-simple-card asoc-simple-card.0: ASoC: CPU DAI 20203000.i2s not registered - will retry
-#  ... snip ...
-# [    9.507142] asoc-simple-card asoc-simple-card.0: snd-soc-dummy-dai <-> 20203000.i2s mapping ok
-
-$ arecord -l
-
-# it should list your mic
-# note that the default vol level is very low, you need
-# to follow the ladyada's guide to make it hearable
-
-
-# If you want it to load automatically at startup
-
-# 1. Add to /etc/modules
-# snd-i2s_rpi
-
-# 2. If you have a Pi old-gen, you need to do this:
-# create file called /etc/modprobe.d/snd-i2s_rpi.conf
-# add this line
-# options snd-i2s_rpi rpi_platform_generation=0
-
-```
-
 
 Installing as a stand-alone module
-====================================
+==============================================================================
 
     make
     sudo make install
@@ -82,33 +18,130 @@ You may also specify custom toolchains by using the `CROSS_COMPILE` flag:
     CROSS_COMPILE=/usr/local/bin/arm-eabi-
 
 
-Installing as a part of the kernel
-======================================
-
-Instructions to come later. Who would ever want to do that?
-
-
-
-
 Installing as a DKMS module
-=================================
+==============================================================================
 
-You can have even more fun with snd-i2s\_rpi by installing it as a DKMS module has the main advantage of being auto-compiled (and thus, possibly surviving) between kernel upgrades.
+You can have even more fun with snd-i2s\_rpi by installing it as a DKMS module
+which has the main advantage of being auto-compiled between kernel upgrades.
 
 First, get dkms. On Raspbian this should be:
 
 	sudo apt install dkms
 
-Then copy the root of this repository to `/usr/share`:
+Then copy the root of this repository to `/usr/src`:
 
-	sudo cp -R . /usr/src/snd-i2s_rpi-0.0.2 (or whatever version number declared on dkms.conf is)
-	sudo dkms add -m snd-i2s_rpi -v 0.0.2
+	sudo cp -R . /usr/src/snd-i2s_rpi-0.0.3 (or whatever version number declared on dkms.conf is)
+	sudo dkms add -m snd-i2s_rpi -v 0.0.3
 
 Build and load the module:
 
-	sudo dkms build -m snd-i2s_rpi -v 0.0.2
-	sudo dkms install -m snd-i2s_rpi -v 0.0.2
+	sudo dkms build -m snd-i2s_rpi -v 0.0.3
+	sudo dkms install -m snd-i2s_rpi -v 0.0.3
 
 Now you have a proper dkms module that will work for a long time... hopefully.
+
+
+Testing the I2S microphone driver
+==============================================================================
+
+```bash
+
+# For this to work, turn on I2S support by adding
+#   dtparam=i2s=on to /boot/config.txt
+
+$ sudo sed -i -e 's/#dtparam=i2s=on/dtparam=i2s=on/g' /boot/config.txt
+
+# Make sure sound support is enabled in the kernel by adding
+#   snd-bcm2835 to /etc/modules
+
+$ sudo sh -c 'echo snd-bcm2835 >> /etc/modules'
+
+# Reboot if you want to test the module before loading it automatically
+
+$ sudo reboot
+
+# Load the module for Raspberry Pi 1 B/A/A+, Zero, Zero W
+$ sudo modprobe snd-i2s_rpi
+
+# Add argument rpi_platform_generation=1 for Raspberry Pi 2 or 3
+# sudo modprobe snd-i2s_rpi rpi_platform_generation=1
+
+# see if it works
+
+$ dmesg | grep i2s
+
+# it should say 20203000.i2s (or 3f203000.i2s) mapping OK
+
+# [    3.519017] snd_i2s_rpi: loading out-of-tree module taints kernel.
+# [    3.519881] snd-i2s_rpi: Version 0.0.3
+# [    3.519889] snd-i2s_rpi: Setting platform to 20203000.i2s
+# [    9.507142] asoc-simple-card asoc-simple-card.0: snd-soc-dummy-dai <-> 20203000.i2s mapping ok
+
+# Running arecord -l should list your new capture device
+
+$ arecord -l
+
+# **** List of CAPTURE Hardware Devices ****
+# card 1: sndrpii2scard [snd_rpi_i2s_card], device 0: simple-card_codec_link snd-soc-dummy-dai-0 [simple-card_codec_link snd-soc-dummy-dai-0]
+#   Subdevices: 0/1
+#   Subdevice #0: subdevice #0
+
+# If you want it to load automatically at startup then
+# add snd-i2s_rpi to /etc/modules
+
+$ sudo sh -c 'echo snd-i2s_rpi >> /etc/modules'
+
+# If you have a Raspberry Pi 2 or 3, you need to do this:
+# create a file called /etc/modprobe.d/snd-i2s_rpi.conf
+# and add this line:
+# options snd-i2s_rpi rpi_platform_generation=1
+
+$ sudo touch /etc/modprobe.d/snd-i2s_rpi.conf
+$ sudo sh -c 'echo "options snd-i2s_rpi rpi_platform_generation=1" >> /etc/modprobe.d/snd-i2s_rpi.conf'
+
+# Test recording with arecord
+
+$ arecord -D plughw:1 -c1 -r 48000 -f S32_LE -t wav -v recording.wav
+
+# If you want to change the volume then create a configuration file for ALSA
+# in your home folder and add a software volume device.
+
+$ cat >> .asoundrc << 'EOF'
+pcm.micsw {
+  type softvol
+  slave.pcm "michw"
+  control {
+    name "micctrl"
+    card sndrpii2scard
+  }
+  min_dB -3.0
+  max_dB 20.0
+}
+
+pcm.michw {
+  type hw
+  card sndrpii2scard
+  channels 2
+  format S32_LE
+}
+EOF
+
+# You might have to use the soft volume device once before the volume slider
+# shows up in alsamixer.
+
+$ arecord -D micsw -c2 -r 48000 -f S32_LE -t wav -V mono -v recording.wav
+
+# If you want to use the microphone using pulseaudio then
+# add the following to /etc/pulse/default.pa
+
+load-module module-alsa-source device=micsw source_name=microphone
+set-default-source microphone
+
+# And add the lines below to /etc/pulse/daemon.conf
+
+default-sample-format = s32le
+default-sample-rate = 48000
+
+```
 
 

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="snd-i2s_rpi"
-PACKAGE_VERSION="0.0.2"
+PACKAGE_VERSION="0.0.3"
 MAKE="KDIR=/lib/modules/$kernelver/build MDIR=/lib/modules/$kernelver make"
 CLEAN="make clean"
 BUILT_MODULE_NAME[0]="snd-i2s_rpi"

--- a/snd-i2s_rpi-km.mk
+++ b/snd-i2s_rpi-km.mk
@@ -1,8 +1,8 @@
-I2SRPI_FOLDER ?= kernel/sound/drivers/snd-i2c_rpi
+I2SRPI_FOLDER ?= kernel/sound/drivers/snd-i2s_rpi
 
 I2SRPI_MODULE:
 	make clean -C $(I2SRPI_FOLDER) KDIR=$(KERNEL_OUT)
-	make -j4 -C $(I2SRPI_FOLDER) ARCH=arm KDIR=$(KERNEL_OUT) \
+	make -C $(I2SRPI_FOLDER) ARCH=arm KDIR=$(KERNEL_OUT) \
 		$(if $(ARM_CROSS_COMPILE),$(ARM_CROSS_COMPILE),$(KERNEL_CROSS_COMPILE))
 	mv $(I2SRPI_FOLDER)/snd-i2s_rpi.ko $(KERNEL_MODULES_OUT)
 	$(if $(ARM_EABI_TOOLCHAIN),$(ARM_EABI_TOOLCHAIN)/arm-eabi-strip, \

--- a/snd-i2s_rpi.c
+++ b/snd-i2s_rpi.c
@@ -3,10 +3,10 @@
  *
  *       Filename:  snd-i2s_rpi
  *
- *    Description:  
+ *    Description:  Driver for the SPH0645LM4H I2S MEMS microphone.
  *
- *        Version:  0.0.2
- *        Created:  2018-03-23
+ *        Version:  0.0.3
+ *        Created:  2020-04-04
  *       Revision:  none
  *       Compiler:  gcc
  *
@@ -40,84 +40,86 @@
 
 void device_release_callback(struct device *dev) { /*  do nothing */ };
 
-static short rpi_platform_generation = 1;
+static short rpi_platform_generation = 0;
 module_param(rpi_platform_generation, short, 0);
 MODULE_PARM_DESC(rpi_platform_generation, "Raspberry Pi generation: 0=Zero, 1=Others");
 
 static struct asoc_simple_card_info default_snd_rpi_simple_card_info = {
-	.card = "snd_rpi_i2s_card", // -> snd_soc_card.name
-	.name = "simple-card_codec_link", // -> snd_soc_dai_link.name
-	.codec = "snd-soc-dummy", // "dmic-codec", // -> snd_soc_dai_link.codec_name
-	.platform = "not-set.i2s",
-	.daifmt = SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_NB_NF | SND_SOC_DAIFMT_CBS_CFS,
-	.cpu_dai = {
-		.name = "not-set.i2s", // -> snd_soc_dai_link.cpu_dai_name
-		.sysclk = 0 
-	},
-	.codec_dai = {
-		.name = "snd-soc-dummy-dai", //"dmic-codec", // -> snd_soc_dai_link.codec_dai_name
-		.sysclk = 0 
-	},
+  .card = "snd_rpi_i2s_card", // -> snd_soc_card.name
+  .name = "simple-card_codec_link", // -> snd_soc_dai_link.name
+  // Available codecs can be found in /sys/kernel/debug/asoc/codecs
+  .codec = "snd-soc-dummy", // -> snd_soc_dai_link.codec_name
+  // ASoC platform strings can be found in /sys/kernel/debug/asoc/platforms
+  .platform = "not-set.i2s",
+  // Note: use SND_SOC_DAIFMT_CBS_CFM instead of SND_SOC_DAIFMT_CBS_CFS
+  // if I2S device must be in slave state.
+  .daifmt = SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_NB_NF | SND_SOC_DAIFMT_CBS_CFS,
+  .cpu_dai = {
+    .name = "not-set.i2s", // -> snd_soc_dai_link.cpu_dai_name
+    .sysclk = 0 
+  },
+  .codec_dai = {
+    // Available dais can be found in /sys/kernel/debug/asoc/dais
+    .name = "snd-soc-dummy-dai", //"dmic-codec", // -> snd_soc_dai_link.codec_dai_name
+    .sysclk = 0 
+  },
 };
 
 static struct platform_device default_snd_rpi_simple_card_device = {
-	.name = "snd_rpi_i2s_card", //module alias
-	.id = 0,
-	.num_resources = 0,
-	.dev = {
-		.release = &device_release_callback,
-		.platform_data = &default_snd_rpi_simple_card_info, // *HACK ALERT*
-	},
+  .name = "asoc-simple-card", // Module alias.
+  .id = 0,
+  .num_resources = 0,
+  .dev = {
+    .release = &device_release_callback,
+    .platform_data = &default_snd_rpi_simple_card_info,
+  },
 };
 
-static char *pri_platform = "3f203000.i2s";
-static char *alt_platform = "20203000.i2s";
-
-static struct asoc_simple_card_info card_info;
-static struct platform_device card_device;
+// ASoC platform strings can be found in /sys/kernel/debug/asoc/platforms
+static const char *pri_platform = "20203000.i2s";  // Zero
+static const char *alt_platform = "3f203000.i2s";  // Others
 
 int i2s_rpi_init(void)
 {
-	const char *dmaengine = "bcm2708-dmaengine"; //module name
-	static char *card_platform;
-	int ret;
+  const char *dmaengine = "bcm2708-dmaengine";
+  const char *card_platform;
+  int ret;
 
-	printk(KERN_INFO "snd-i2s_rpi: Version %s\n", SND_I2S_RPI_VERSION);
+  printk(KERN_INFO "snd-i2s_rpi: Version %s\n", SND_I2S_RPI_VERSION);
 
-	card_platform = pri_platform;
-	if (rpi_platform_generation == 0) {
-		card_platform = alt_platform;
-	}
+  card_platform = pri_platform;
+  if (rpi_platform_generation != 0) {
+    card_platform = alt_platform;
+  }
 
-	printk(KERN_INFO "snd-i2s_rpi: Setting platform to %s\n", card_platform);
+  printk(KERN_INFO "snd-i2s_rpi: Setting platform to %s\n", card_platform);
 
-	ret = request_module(dmaengine);
-	// pr_alert("request module load '%s': %d\n",dmaengine, ret);
+  ret = request_module(dmaengine);
+  if (ret != 0) {
+    pr_alert("Unable to request module load '%s': %d\n",
+             dmaengine, ret);
+  }
 
-	card_info = default_snd_rpi_simple_card_info;
-	card_info.platform = card_platform;
-	card_info.cpu_dai.name = card_platform;
+  default_snd_rpi_simple_card_info.platform = card_platform;
+  default_snd_rpi_simple_card_info.cpu_dai.name = card_platform;
 
-	card_device = default_snd_rpi_simple_card_device;
-	card_device.dev.platform_data = &card_info;
+  ret = platform_device_register(&default_snd_rpi_simple_card_device);
+  if (ret != 0) {
+    pr_alert("Unable to register platform device '%s': %d\n",
+             default_snd_rpi_simple_card_device.name, ret);
+  }
 
-	ret = platform_device_register(&card_device);
-
-	//pr_alert("register platform device '%s': %d\n",snd_rpi_simple_card_device.name, ret);
-
-	return 0;
+  return ret;
 }
 
 void i2s_rpi_exit(void)
 {
-	// you'll have to sudo modprobe -r the card & codec drivers manually (first?)
-	platform_device_unregister(&card_device);
-	//pr_alert("i2s mic module unloaded\n");
+  platform_device_unregister(&default_snd_rpi_simple_card_device);
 }
-
 
 module_init(i2s_rpi_init);
 module_exit(i2s_rpi_exit);
+
 MODULE_DESCRIPTION("ASoC simple-card I2S Microphone");
 MODULE_AUTHOR("Huan Truong <htruong@tnhh.net>");
 MODULE_LICENSE("GPL v2");

--- a/version.h
+++ b/version.h
@@ -1,1 +1,1 @@
-#define SND_I2S_RPI_VERSION  "0.0.2"
+#define SND_I2S_RPI_VERSION  "0.0.3"


### PR DESCRIPTION
- Fixed typo in install target.
- Fixed typo in module makefile.
- Changed module alias in the platform_device structure.
- Made Pi zero the default ASoC platform.
- Added logs for non-zero return values.
- Updated readme.